### PR TITLE
Featutre/switch income

### DIFF
--- a/src/components/BudgetForm.css
+++ b/src/components/BudgetForm.css
@@ -4,3 +4,60 @@
   border: 1px solid #ddd;
   border-radius: 12px;
 }
+.toggle-container {
+  align-items: center;
+  justify-content: center;
+  display: flex;
+}
+.toggle-button-4 {
+    display: flex;
+    align-items: center;
+    position: relative;
+    width: 100px;
+    height: 50px;
+    border-radius: 50px;
+    box-sizing: content-box;
+    background-color: #9dffa033;
+    cursor: pointer;
+    transition: background-color .4s;
+}
+
+.toggle-button-4:has(:checked) {
+    background-color: #ff8d8d33;
+}
+
+.toggle-button-4::before {
+    position: absolute;
+    left: 5px;
+    width: 42px;
+    height: 42px;
+    border-radius: 50%;
+    background-color: rgb(10, 150, 0);
+    content: '';
+    transition: left .4s;
+}
+
+.toggle-button-4:has(:checked)::before {
+    left: 50px;
+    background-color: #ff0000;
+}
+
+.toggle-button-4::after {
+    position: absolute;
+    left: 26px;
+    transform: translateX(-50%);
+    color: #fff;
+    font-weight: 600;
+    font-size: .9em;
+    content: "収入";
+    transition: left .4s;
+}
+
+.toggle-button-4:has(:checked)::after {
+    left: 71px;
+    content: "支出";
+}
+
+.toggle-button-4 input {
+    display: none;
+}

--- a/src/components/BudgetForm.jsx
+++ b/src/components/BudgetForm.jsx
@@ -32,7 +32,7 @@ const BudgetForm = () => {
       await addDoc(collection(db, "budget"), {
         ...budget,
         money: Number(budget.money),
-        type: isIncome ? "income" : "expense"
+        type: isIncome ? "expense" : "income"
       });
       alert("追加完了しました");
       setBudget({

--- a/src/components/BudgetForm.jsx
+++ b/src/components/BudgetForm.jsx
@@ -4,6 +4,9 @@ import { addDoc, collection } from "firebase/firestore";
 import { db } from "../Firebase";
 
 const BudgetForm = () => {
+  const expenseCategories = ["食費", "光熱費", "家賃", "交際費", "日用品費"]
+  const incomeCategories = ["給与", "ボーナス", "お小遣い"]
+  const [isIncome, setIsIncome] = useState(false);
   const [budget, setBudget] = useState({
     date: "",
     money: "",
@@ -20,13 +23,16 @@ const BudgetForm = () => {
     if (
       (budget.date) === "" ||
       (budget.money) === "" ||
-      (budget.category) === "" ||
-      (budget.memo) === ""
-    ) { alert("入力してください"); return }
+      (budget.memo) === "" ||
+      (budget.category) === ""
+    ) {
+      alert("入力してください"); return
+    }
     try {
       await addDoc(collection(db, "budget"), {
         ...budget,
         money: Number(budget.money),
+        type: isIncome ? "income" : "expense"
       });
       alert("追加完了しました");
       setBudget({
@@ -42,6 +48,15 @@ const BudgetForm = () => {
 
   return (
     <div className="budget-form">
+      <div className="toggle-container">
+        <label className="toggle-button-4">
+          <input
+            type="checkbox"
+            checked={isIncome}
+            onChange={(e) => setIsIncome(e.target.checked)}
+          />
+        </label>
+      </div>
       <div className="date-form">
         <label htmlFor="date">日付</label>
         <input
@@ -70,11 +85,15 @@ const BudgetForm = () => {
           onChange={handleBudget}
           id="category">
           <option value="">カテゴリーを選択してください</option>
-          <option value="食費">食費</option>
-          <option value="光熱費">光熱費</option>
-          <option value="家賃">家賃</option>
-          <option value="交際費">交際費</option>
-          <option value="日用品費">日用品費</option>
+          {isIncome
+            ? expenseCategories.map((cat) => (
+              <option key={cat} value={cat}>{cat}</option>
+            ))
+            :
+            incomeCategories.map((cat) => (
+              <option key={cat} value={cat}>{cat}</option>
+            ))
+          }
         </select>
       </div>
       <div>

--- a/src/components/Summary.css
+++ b/src/components/Summary.css
@@ -9,7 +9,7 @@
 }
 
 .income {
-  color: rgb(17, 255, 0);
+  color: rgb(10, 150, 0);
   font-weight: bold;
   font-size: large;
 }

--- a/src/components/Summary.jsx
+++ b/src/components/Summary.jsx
@@ -4,25 +4,31 @@ import { db } from "../Firebase";
 import './Summary.css';
 
 const Summary = () => {
-  const [totals, setTotals] = useState(0);
-  const income = 500000 //ここは後日機能実装予定
+  const [income, setIncome] = useState(0);
+  const [expense, setExpense] = useState(0);
 
   useEffect(() => {
-    const getTotalMoney = () => {
-      const unsubscribe = onSnapshot(collection(db, "budget"), (snapshot) => {
-        const data = snapshot.docs.map(doc => doc.data());
-        const computed = data.reduce((acc, budget) => {
-          const money = budget.money;
-          acc = acc + money;
+    const unsubscribe = onSnapshot(collection(db, "budget"), (snapshot) => {
+      const data = snapshot.docs.map(doc => doc.data());
+      const computed = data.reduce(
+        (acc, budget) => {
+          if (budget.type === "income") {
+            acc.income += budget.money;
+          }
+          else if (budget.type === "expense") {
+            acc.expense += budget.money
+          }
           return acc;
-        }, 0);
-        setTotals(computed);
-      });
-      return () => unsubscribe();
-    };
-    getTotalMoney()
+        },
+        { income: 0, expense: 0 }
+      );
+
+      setIncome(computed.income);
+      setExpense(computed.expense)
+    });
+    return () => unsubscribe();
   }, [])
-  const balance = income - totals;
+  const balance = income - expense;
 
 
   return (
@@ -33,7 +39,7 @@ const Summary = () => {
       </span>
       <span>
         <p>支出</p>
-        <p className="expense">￥{totals}</p>
+        <p className="expense">￥{expense}</p>
       </span>
       <span>
         <p>残高</p>


### PR DESCRIPTION
支出と収入のタイプがFirestore上で意味が逆になっていたため条件を修正
支出のみの計算式へ条件文を用いて収入の計算も対応
SummaryのuseStateをtotalsからincome、expenseの2種類に変更
